### PR TITLE
Fix label visibility in registration form

### DIFF
--- a/src/View/view_inscription.php
+++ b/src/View/view_inscription.php
@@ -11,7 +11,7 @@
                     <h1 class="card-title text-center text-primary">Sign-in</h1>
                     <form action="" method="POST" novalidate>
                         <div class="mb-3">
-                            <label for="nom" class="form-label">Nom:</label>
+                            <label for="nom" class="form-label text-light">Nom:</label>
                             <input type="text"
                                 class="form-control <?php echo isset($errors['nom']) ? 'is-invalid' : ''; ?>" id="nom"
                                 name="nom" value="<?= $_POST['nom'] ?? '' ?>" required>
@@ -23,7 +23,7 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="prenom" class="form-label">Prénom:</label>
+                            <label for="prenom" class="form-label text-light">Prénom:</label>
                             <input type="text"
                                 class="form-control <?php echo isset($errors['prenom']) ? 'is-invalid' : ''; ?>"
                                 id="prenom" name="prenom" value="<?= $_POST['prenom'] ?? '' ?>" required>
@@ -35,7 +35,7 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="pseudo" class="form-label">Pseudo:</label>
+                            <label for="pseudo" class="form-label text-light">Pseudo:</label>
                             <input type="text"
                                 class="form-control <?php echo isset($errors['pseudo']) ? 'is-invalid' : ''; ?>"
                                 id="pseudo" name="pseudo" value="<?= $_POST['pseudo'] ?? '' ?>" required>
@@ -47,7 +47,7 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="email" class="form-label">Email:</label>
+                            <label for="email" class="form-label text-light">Email:</label>
                             <input type="email"
                                 class="form-control <?php echo isset($errors['email']) ? 'is-invalid' : ''; ?>"
                                 id="email" name="email" value="<?= $_POST['email'] ?? '' ?>" required>
@@ -59,7 +59,7 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="password" class="form-label">Mot de passe: (Maj, numb, min, special)</label>
+                            <label for="password" class="form-label text-light">Mot de passe: (Maj, numb, min, special)</label>
                             <input type="password"
                                 class="form-control <?php echo isset($errors['password']) ? 'is-invalid' : ''; ?>"
                                 id="password" name="password" required>
@@ -71,7 +71,7 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="confirm_password" class="form-label">Confirmez le mot de passe:</label>
+                            <label for="confirm_password" class="form-label text-light">Confirmez le mot de passe:</label>
                             <input type="password"
                                 class="form-control <?php echo isset($errors['confirm_password']) ? 'is-invalid' : ''; ?>"
                                 id="confirm_password" name="confirm_password" required>
@@ -83,7 +83,7 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="dob" class="form-label">Date de naissance:</label>
+                            <label for="dob" class="form-label text-light">Date de naissance:</label>
                             <input type="date"
                                 class="form-control <?php echo isset($errors['dob']) ? 'is-invalid' : ''; ?>" id="dob"
                                 name="dob" value="<?= $_POST['dob'] ?? '' ?>" required>
@@ -95,7 +95,7 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="genre" class="form-label">Genre:</label>
+                            <label for="genre" class="form-label text-light">Genre:</label>
                             <select class="form-control <?php echo isset($errors['genre']) ? 'is-invalid' : ''; ?>"
                                 id="genre" name="genre" required>
                                 <option value="" disabled <?php echo !isset($_POST['genre']) ? 'selected' : ''; ?>>--
@@ -113,7 +113,7 @@
 
                         <div class="mb-3">
                             <input type="checkbox" class="form-check-input" id="terms" name="terms" value="1" <?php echo isset($_POST['terms']) ? 'checked' : ''; ?> required>
-                            <label class="form-check-label" for="terms">J'accepte les conditions d'utilisation</label>
+                            <label class="form-check-label text-light" for="terms">J'accepte les conditions d'utilisation</label>
                         </div>
 
                         <button type="submit" class="btn btn-primary w-100">Sign-in</button>


### PR DESCRIPTION
## Summary
- ensure labels on sign-in page are visible by applying `text-light` class

## Testing
- `php -l src/View/view_inscription.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852c9f4d5e8832296b70309da896e18