### PR TITLE
Fix terms checkbox error feedback

### DIFF
--- a/src/View/view_inscription.php
+++ b/src/View/view_inscription.php
@@ -96,8 +96,11 @@
                         </div>
 
                         <div class="mb-3">
-                            <input type="checkbox" class="form-check-input" id="terms" name="terms" value="1" <?php echo isset($_POST['terms']) ? 'checked' : ''; ?> required>
+                            <input type="checkbox" class="form-check-input <?php echo isset($errors['terms']) ? 'is-invalid' : ''; ?>" id="terms" name="terms" value="1" <?php echo isset($_POST['terms']) ? 'checked' : ''; ?> required>
                             <label class="form-check-label text-light" for="terms">Accept conditions</label>
+                            <?php if (isset($errors['terms'])): ?>
+                                <div class="invalid-feedback d-block"><?= $errors['terms'] ?></div>
+                            <?php endif; ?>
                         </div>
 
                         <button type="submit" class="btn btn-primary w-100">Sign-in</button>


### PR DESCRIPTION
## Summary
- show an invalid feedback message for the terms acceptance checkbox on sign up form

## Testing
- *No tests in repository*

------
https://chatgpt.com/codex/tasks/task_e_6853c2a2b9688322b63cf9179228f494